### PR TITLE
Cannot bind argument to parameter 'LiteralPath' because it is null.

### DIFF
--- a/pso2_winstore_fix.ps1
+++ b/pso2_winstore_fix.ps1
@@ -1672,7 +1672,7 @@ If ($UTPackages.Count -eq 1)
 	$PSO2NABinFolder_FallBack = Join-Path $UTPackages.InstallLocation -ChildPath "pso2_bin"
 }
 
-If (-Not (Test-Path -LiteralPath $PSO2NABinFolder_FallBack))
+If (($null -eq $PSO2NABinFolder_FallBack) -or (-Not (Test-Path -LiteralPath $PSO2NABinFolder_FallBack)))
 {
 	$PSO2NABinFolder_FallBack = "C:\PHANTASYSTARONLINE2_NA\pso2_bin"
 }


### PR DESCRIPTION
```
Cannot bind argument to parameter 'LiteralPath' because it is null.
Test-Path : Cannot bind argument to parameter 'LiteralPath' because it is null.
At .\pso2_winstore_fix.ps1:1675 char:34
If (-Not (Test-Path -LiteralPath $PSO2NABinFolder_FallBack))
```